### PR TITLE
feat: Improve folder loading and size calculation

### DIFF
--- a/src/components/FolderItem.js
+++ b/src/components/FolderItem.js
@@ -209,19 +209,26 @@ const FolderItem = ({ folder, onPress, showCounts, showProgress }) => {
                 <View style={styles.infoContainer}>
                     <Text style={styles.name} numberOfLines={1}>{folder.name}</Text>
 
-                    {showProgress && <View style={styles.detailsRow}>
-                        <Text style={styles.itemCount}>{folder.totalCount} items</Text>
-                        {folder.totalSize > 0 && (
-                            <>
-                                <Text style={styles.separator}>•</Text>
-                                <Text style={styles.itemCount}>{formatBytes(folder.totalSize)}</Text>
-                            </>
-                        )}
-                        <Text style={styles.separator}>•</Text>
-                        <Text style={[styles.statusText, statusDisplay.style]}>
-                            {statusDisplay.text}
+                    {showProgress && (
+                        <View style={styles.detailsRow}>
+                            <Text style={styles.itemCount}>{folder.totalCount} items</Text>
+                            {folder.totalSize > 0 && !folder.isSkipped && (
+                                <>
+                                    <Text style={styles.separator}>•</Text>
+                                    <Text style={styles.itemCount}>{formatBytes(folder.totalSize)}</Text>
+                                </>
+                            )}
+                            <Text style={styles.separator}>•</Text>
+                            <Text style={[styles.statusText, statusDisplay.style]}>
+                                {statusDisplay.text}
+                            </Text>
+                        </View>
+                    )}
+                    {folder.isSkipped && (
+                        <Text style={[styles.itemCount, { color: colors.textTertiary, fontStyle: 'italic' }]}>
+                            Folder size calculation skipped due to item count.
                         </Text>
-                    </View>}
+                    )}
                 </View>
 
                 {/* Media type pills and indicator */}

--- a/src/screens/Folders.js
+++ b/src/screens/Folders.js
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, FlatList } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, FlatList, Animated } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useMedia } from '../contexts/MediaContext';
 import { useTheme } from '../contexts/ThemeContext';
@@ -8,6 +8,29 @@ import * as MediaLibrary from 'expo-media-library';
 import { useNavigation } from '@react-navigation/native';
 import { useFocusEffect } from '@react-navigation/native';
 import { useAppState } from '../contexts/AppStateContext';
+
+const ProgressBar = ({ progress, height = 4, color = '#007AFF' }) => {
+    const animatedWidth = useMemo(() => new Animated.Value(progress), []);
+
+    useEffect(() => {
+        Animated.timing(animatedWidth, {
+            toValue: progress,
+            duration: 200,
+            useNativeDriver: false,
+        }).start();
+    }, [progress]);
+
+    const width = animatedWidth.interpolate({
+        inputRange: [0, 1],
+        outputRange: ['0%', '100%'],
+    });
+
+    return (
+        <View style={{ height, backgroundColor: 'rgba(0, 122, 255, 0.2)', borderRadius: height / 2 }}>
+            <Animated.View style={{ height, width, backgroundColor: color, borderRadius: height / 2 }} />
+        </View>
+    );
+};
 
 export default function Folders() {
     const { colors, hideCompleted, showMediaCounts, showProgress } = useTheme();
@@ -142,10 +165,16 @@ export default function Folders() {
             fontSize: 16,
             marginTop: 12
         },
+        loadingContainer: {
+            paddingHorizontal: 20,
+            paddingVertical: 10,
+            borderBottomWidth: 1,
+            borderBottomColor: colors.border,
+        },
         loadingText: {
             color: colors.textSecondary,
-            marginTop: 12,
-            fontSize: 14,
+            fontSize: 12,
+            marginBottom: 8,
         },
         errorText: {
             color: '#ff5555',
@@ -265,21 +294,6 @@ export default function Folders() {
         );
     }
 
-    if (loading.all) {
-        let loadingMessage = 'Loading folders...';
-        if (loading.status === 'metadata') loadingMessage = 'Fetching metadata...';
-        if (loading.status === 'sizing') loadingMessage = 'Calculating folder sizes...';
-
-        return (
-            <View style={styles.container}>
-                <View style={styles.centerContent}>
-                    <ActivityIndicator size="large" color={colors.textSecondary} />
-                    <Text style={styles.loadingText}>{loadingMessage}</Text>
-                </View>
-            </View>
-        );
-    }
-
     if (errors.all) {
         return (
             <View style={styles.container}>
@@ -304,10 +318,11 @@ export default function Folders() {
                 <View>
                     <Text style={styles.headerTitle}>Media Folders</Text>
                     <Text style={styles.headerSubtitle}>
-                        {folders.length} folder{folders.length !== 1 ? 's' : ''}
+                        {loading.all && loading.total > 0
+                            ? `Loaded ${loading.loaded}/${loading.total} folders`
+                            : `${folders.length} folder${folders.length !== 1 ? 's' : ''}`}
                         {summaryStats.completed > 0 && ` • ${summaryStats.completed} completed`}
                         {summaryStats.hasInProgress && ' • 1 in progress'}
-                        {lastRefreshed && ` • Updated ${new Date(lastRefreshed).toLocaleTimeString()}`}
                     </Text>
                 </View>
 
@@ -323,6 +338,15 @@ export default function Folders() {
                     />
                 </TouchableOpacity>
             </View>
+
+            {loading.all && (
+                <View style={styles.loadingContainer}>
+                    <Text style={styles.loadingText}>
+                        {loading.status || 'Calculating...'}
+                    </Text>
+                    <ProgressBar progress={loading.progress || 0} />
+                </View>
+            )}
 
             {/* Active session banner */}
             {summaryStats.hasInProgress && summaryStats.activeSessionFolder && showProgress && (
@@ -372,16 +396,18 @@ export default function Folders() {
                     renderItem={renderFolderItem}
                     contentContainerStyle={styles.listContent}
                     ListEmptyComponent={
-                        <View style={styles.emptyContainer}>
-                            <Ionicons name="folder-outline" size={48} color={colors.textSecondary} />
-                            <Text style={styles.emptyText}>No media folders found</Text>
-                            <TouchableOpacity
-                                onPress={refreshAllData}
-                                style={[styles.button, { marginTop: 16 }]}
-                            >
-                                <Text style={styles.buttonText}>Refresh</Text>
-                            </TouchableOpacity>
-                        </View>
+                        !loading.all && (
+                            <View style={styles.emptyContainer}>
+                                <Ionicons name="folder-outline" size={48} color={colors.textSecondary} />
+                                <Text style={styles.emptyText}>No media folders found</Text>
+                                <TouchableOpacity
+                                    onPress={refreshAllData}
+                                    style={[styles.button, { marginTop: 16 }]}
+                                >
+                                    <Text style={styles.buttonText}>Refresh</Text>
+                                </TouchableOpacity>
+                            </View>
+                        )
                     }
                     refreshing={!!loading.all}
                     onRefresh={() => refreshAllData(true)}

--- a/src/utils/Settings.js
+++ b/src/utils/Settings.js
@@ -1,0 +1,31 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const SETTINGS_KEYS = {
+    FOLDER_ITEM_LIMIT: '@Settings:FolderItemLimit',
+    // Add other settings keys here
+};
+
+export const DEFAULT_SETTINGS = {
+    [SETTINGS_KEYS.FOLDER_ITEM_LIMIT]: 10000,
+};
+
+export const getSetting = async (key) => {
+    try {
+        const value = await AsyncStorage.getItem(key);
+        if (value !== null) {
+            return JSON.parse(value);
+        }
+        return DEFAULT_SETTINGS[key];
+    } catch (error) {
+        console.warn(`Failed to get setting for key: ${key}`, error);
+        return DEFAULT_SETTINGS[key];
+    }
+};
+
+export const setSetting = async (key, value) => {
+    try {
+        await AsyncStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+        console.error(`Failed to save setting for key: ${key}`, error);
+    }
+};


### PR DESCRIPTION
This commit introduces several improvements to the folder screen to enhance your experience and performance.

- **Fix Folder Size Calculation:** The folder size calculation now correctly includes video files, providing a more accurate representation of folder sizes.
- **Implement Partial Loading:** The folder screen now loads and displays folders incrementally, showing a progress bar and status indicator. This allows you to see and interact with loaded folders while the rest are still being processed, instead of waiting for the entire list to be ready.
- **Add Folder Item Limit Setting:** A new setting has been added to allow you to specify a folder item limit. Folders with more items than this limit will be skipped during the scanning process to improve performance. The default limit is 10,000, and it can be configured in the settings screen (from 500 to no limit).
- **UI/UX Enhancements:**
  - Skipped folders are now indicated in the UI.
  - The folder loading process is more transparent with a progress bar and status updates.